### PR TITLE
Replacement of hard-coded string in MachineReader.cs

### DIFF
--- a/Modbus.Net/Modbus.Net/Configuration/MachineReader.cs
+++ b/Modbus.Net/Modbus.Net/Configuration/MachineReader.cs
@@ -16,7 +16,7 @@ namespace Modbus.Net
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.default.json", optional: false, reloadOnChange: true)
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? Environments.Production}.json", optional: true, reloadOnChange: true)
             .Build();
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Modbus.Net
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.default.json", optional: false, reloadOnChange: true)
             .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ?? Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? Environments.Production}.json", optional: true, reloadOnChange: true)
             .Build();
 
         public static IEnumerable<AddressUnit<TUnitKey, TAddressKey, TSubAddressKey>> ReadAddresses(string addressMapName)


### PR DESCRIPTION
Replacement of hard-coded string "Production" to utilizing the constant Environments.Production provided by the ASP.NET Core framework.
The change enhances the code quality by leveraging framework-provided constants, thereby making the solutions using the example code more maintainable, robust, and aligned with best practices.